### PR TITLE
fix(agents): output_dir/signing_mode sentinel matches its own substituted value (#5 regression)

### DIFF
--- a/claude/agents/shortcut-builder.md
+++ b/claude/agents/shortcut-builder.md
@@ -46,7 +46,7 @@ Follow this sequence for every build. **Every step is mandatory**, including res
     CONFIGURED_OUTPUT_DIR="${user_config.output_dir}"
     CONFIGURED_SIGNING_MODE="${user_config.signing_mode}"
     case "$CONFIGURED_OUTPUT_DIR" in
-      ""|'${user_config.output_dir}') OUTPUT_DIR="${CLAUDE_PLUGIN_OPTION_OUTPUT_DIR:-$HOME/Documents/Shortcuts Playground}" ;;
+      ""|'${'*) OUTPUT_DIR="${CLAUDE_PLUGIN_OPTION_OUTPUT_DIR:-$HOME/Documents/Shortcuts Playground}" ;;
       *) OUTPUT_DIR="$CONFIGURED_OUTPUT_DIR" ;;
     esac
     case "$OUTPUT_DIR" in
@@ -56,7 +56,7 @@ Follow this sequence for every build. **Every step is mandatory**, including res
       '$HOME/'*) OUTPUT_DIR="$HOME/${OUTPUT_DIR#\$HOME/}" ;;
     esac
     case "$CONFIGURED_SIGNING_MODE" in
-      ""|'${user_config.signing_mode}') SIGNING_MODE="${CLAUDE_PLUGIN_OPTION_SIGNING_MODE:-anyone}" ;;
+      ""|'${'*) SIGNING_MODE="${CLAUDE_PLUGIN_OPTION_SIGNING_MODE:-anyone}" ;;
       *) SIGNING_MODE="$CONFIGURED_SIGNING_MODE" ;;
     esac
     mkdir -p "$OUTPUT_DIR/drafts"

--- a/claude/agents/shortcut-remixer.md
+++ b/claude/agents/shortcut-remixer.md
@@ -69,7 +69,7 @@ Before any other work, run this Bash command:
 CONFIGURED_OUTPUT_DIR="${user_config.output_dir}"
 CONFIGURED_SIGNING_MODE="${user_config.signing_mode}"
 case "$CONFIGURED_OUTPUT_DIR" in
-  ""|'${user_config.output_dir}') OUTPUT_DIR="${CLAUDE_PLUGIN_OPTION_OUTPUT_DIR:-$HOME/Documents/Shortcuts Playground}" ;;
+  ""|'${'*) OUTPUT_DIR="${CLAUDE_PLUGIN_OPTION_OUTPUT_DIR:-$HOME/Documents/Shortcuts Playground}" ;;
   *) OUTPUT_DIR="$CONFIGURED_OUTPUT_DIR" ;;
 esac
 case "$OUTPUT_DIR" in
@@ -79,7 +79,7 @@ case "$OUTPUT_DIR" in
   '$HOME/'*) OUTPUT_DIR="$HOME/${OUTPUT_DIR#\$HOME/}" ;;
 esac
 case "$CONFIGURED_SIGNING_MODE" in
-  ""|'${user_config.signing_mode}') SIGNING_MODE="${CLAUDE_PLUGIN_OPTION_SIGNING_MODE:-anyone}" ;;
+  ""|'${'*) SIGNING_MODE="${CLAUDE_PLUGIN_OPTION_SIGNING_MODE:-anyone}" ;;
   *) SIGNING_MODE="$CONFIGURED_SIGNING_MODE" ;;
 esac
 mkdir -p "$OUTPUT_DIR/drafts"


### PR DESCRIPTION
## Summary

The `output_dir` / `signing_mode` fix for #5 (commit 675e7a9) does not hold in the case it was written for: when `output_dir` **is** configured, both agents still fall through to `~/Documents/Shortcuts Playground`.

Step 0 of `shortcut-builder.md` and `shortcut-remixer.md` detects "not substituted" with a `case` pattern that spells out the placeholder:

```bash
CONFIGURED_OUTPUT_DIR="${user_config.output_dir}"
case "$CONFIGURED_OUTPUT_DIR" in
  ""|'${user_config.output_dir}') OUTPUT_DIR="${CLAUDE_PLUGIN_OPTION_OUTPUT_DIR:-$HOME/Documents/Shortcuts Playground}" ;;
  *) OUTPUT_DIR="$CONFIGURED_OUTPUT_DIR" ;;
esac
```

Claude Code substitutes `${user_config.<key>}` everywhere in the agent text — the pattern included. With a configured value, the assignment and the pattern become the same string, the pattern matches itself, and the code takes the fallback branch. `CLAUDE_PLUGIN_OPTION_OUTPUT_DIR` is not exported to ordinary Bash tool calls (the prompt says so itself a few lines later), so the configured directory is silently ignored. Same for `signing_mode`, which then silently signs `anyone`.

This is what the agent actually executed on Claude Code 2.1.260 / macOS 26.6.2 / plugin 1.2.1 with `output_dir` set via `--config`:

```
CONFIGURED_OUTPUT_DIR="/Users/…/_infra/shortcuts/out"   # substituted correctly
OUTPUT_DIR=/Users/…/Documents/Shortcuts Playground      # fallback taken anyway
```

(The builder noticed the mismatch and worked around it by passing `--output-dir` explicitly; a less careful run just writes to the wrong place.)

## Fix

Match the *unsubstituted* form by prefix instead of by full literal:

```bash
  ""|'${'*) …
```

The pattern no longer contains `${user_config.`, so substitution leaves it alone; a real configured value falls through to `*)`; and if nothing was substituted, bash rejects `${user_config.output_dir}` as a bad substitution and the empty result is caught by `""` (the `'${'*` alternative keeps the original intent explicit). Applied to `output_dir` and `signing_mode` in both agents — four lines.

## Verification

Extracted the step-0 block from both versions, applied the substitution the way Claude Code does (`output_dir=/Users/…/_infra/shortcuts/out`, `signing_mode=people-who-know-me`), and ran it:

```
1.2.1    → OUTPUT_DIR=/tmp/fakehome/Documents/Shortcuts Playground  SIGNING_MODE=anyone
this PR  → OUTPUT_DIR=/Users/…/_infra/shortcuts/out                 SIGNING_MODE=people-who-know-me
```

`shortcuts-playground-selftest` passes with the patched agents installed. No changes to `bin/`, hooks, validator or the skill; CHANGELOG left untouched to keep the diff minimal — happy to add a line if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
